### PR TITLE
Fix np.random.randint raising ValueError (#8)

### DIFF
--- a/sybil/serie.py
+++ b/sybil/serie.py
@@ -129,7 +129,7 @@ class Serie:
             CT volume of shape (1, C, N, H, W)
         """
 
-        sample = {"seed": np.random.randint(0, 2**32 - 1)}
+        sample = {"seed": np.random.randint(0, 2**32 - 1, dtype=np.int64)}
 
         input_dicts = [self._loader.get_image(path, sample) for path in self._meta.paths]
         


### PR DESCRIPTION
I also encountered the error described in the issue mentioned in the commit.

Applying [jryoungw](https://github.com/jryoungw)'s fix did indeed solve the issue on my side, and I was able to run inference on Windows.