### PR TITLE
docs: add AXIO PREDICT (open-source desktop GUI for Sybil) to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ Lung Cancer Risk Prediction.
 
 Additional documentation can be found on the [GitHub Wiki](https://github.com/reginabarzilaygroup/Sybil/wiki).
 
+# Desktop App: AXIO PREDICT
+
+[**AXIO PREDICT**](https://github.com/godsonj64/AXIOPREDICT) is a free, open-source (MIT) cross-platform desktop application that runs the Sybil ensemble locally behind a graphical interface — no coding required. It accepts DICOM or PNG LDCT series, produces calibrated 1–6 year lung-cancer risk scores, visualises Sybil's attention maps, and includes an audit toolkit for inspecting prediction quality. All inference runs on-device, so no patient data leaves the machine.
+
+- **Download:** [latest release](https://github.com/godsonj64/AXIOPREDICT/releases/latest) — Windows installer & portable build; macOS/Linux build from source
+- **Source & docs:** https://github.com/godsonj64/AXIOPREDICT
+
+> AXIO PREDICT is an independent community project built on Sybil and intended for research use only. Please cite the Sybil paper (see [Cite](#cite)) when using it.
+
 # Run a regression test
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Additional documentation can be found on the [GitHub Wiki](https://github.com/re
 
 [**AXIO PREDICT**](https://github.com/godsonj64/AXIOPREDICT) is a free, open-source (MIT) cross-platform desktop application that runs the Sybil ensemble locally behind a graphical interface — no coding required. It accepts DICOM or PNG LDCT series, produces calibrated 1–6 year lung-cancer risk scores, visualises Sybil's attention maps, and includes an audit toolkit for inspecting prediction quality. All inference runs on-device, so no patient data leaves the machine.
 
-- **Download:** [latest release](https://github.com/godsonj64/AXIOPREDICT/releases/latest) — Windows installer & portable build; macOS/Linux build from source
+- **Download:** [latest release](https://github.com/godsonj64/AXIOPREDICT/releases/latest) — prebuilt **Windows** (installer & portable) and **macOS** (Universal DMG, Apple Silicon + Intel); Linux builds from source
 - **Source & docs:** https://github.com/godsonj64/AXIOPREDICT
 
 > AXIO PREDICT is an independent community project built on Sybil and intended for research use only. Please cite the Sybil paper (see [Cite](#cite)) when using it.


### PR DESCRIPTION
## Summary

This adds a short section to the README pointing to **[AXIO PREDICT](https://github.com/godsonj64/AXIOPREDICT)** — a free, open-source (MIT) cross-platform desktop application that runs the Sybil ensemble locally behind a graphical interface, so clinicians and researchers can use Sybil without writing any code.

- **DICOM & PNG** LDCT input, axial, auto-sorted by z-position
- Calibrated **1–6 year** lung-cancer risk scores
- **Attention-map** GIF visualisation (built on Sybil's `visualize_attentions`)
- **Audit toolkit** for inspecting attention/prediction quality
- **Fully local** — model weights and patient data stay on the machine
- Downloads: [latest release](https://github.com/godsonj64/AXIOPREDICT/releases/latest) (Windows installer + portable build; macOS/Linux build from source)

The app credits and cites Sybil and links back to this repository. This change is **documentation-only** — a single section added near the top of the README.

Happy to reword it, move it (e.g. into a "Related projects" area or the bottom of the README), or trim it to one line if you'd prefer. Thank you for releasing Sybil!
