### PR TITLE
Allow Sybil to be tested on CPU-only environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+tests/*calibrations.json
 
 # Translations
 *.mo
@@ -133,6 +134,10 @@ dmypy.json
 # Editors
 .vscode/
 .idea/
+.cursorindexingignore
+
+# Specstory
+.specstory/
 
 # Vagrant
 .vagrant/

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,8 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 tests/*calibrations.json
+tests/nlst_predictions/
+regression_test_output/
 
 # Translations
 *.mo

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Lung Cancer Risk Prediction.
 
 Additional documentation can be found on the [GitHub Wiki](https://github.com/reginabarzilaygroup/Sybil/wiki).
 
+# Installation
+
+Installation can be found in the Wiki. Note that you will need Python >=3.8, <3.11.
+
 # Run a regression test
 
 ```shell

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ install_requires =
     pylibjpeg[all]==2.0.0
     torchio==0.18.74
     tqdm==4.62.3
+    requests==2.34.2
 
 [options.packages.find]
 exclude =

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,7 @@ testing =
     flake8
     mypy
     black
+    tox
 train =
     albumentations==1.1.0
     lifelines==0.26.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ classifiers =
     Programming Language :: Python
 
 [easy_install]
+# Only needed if installing the optional `gpu` extra below
 find_links =
     https://download.pytorch.org/whl/cu117/torch_stable.html
 
@@ -45,17 +46,14 @@ install_requires =
     pillow>=10.2.0
     pydicom==2.3.0
     pylibjpeg[all]==2.0.0
-    torch==1.13.1+cu117; platform_machine == "x86_64"
-    torch==1.13.1; platform_machine != "x86_64"
+    torch==1.13.1
     torchio==0.18.74
-    torchvision==0.14.1+cu117; platform_machine == "x86_64"
-    torchvision==0.14.1; platform_machine != "x86_64"
+    torchvision==0.14.1
     tqdm==4.62.3
 
 [options.packages.find]
 exclude =
     tests
-
 
 [options.extras_require]
 # Add here test requirements (semicolon/line-separated)
@@ -71,6 +69,9 @@ train =
     lifelines==0.26.4
     pytorch_lightning==1.6.0
     scikit-learn==1.0.2
+gpu =
+    torch==1.13.1+cu117
+    torchvision==0.14.1+cu117
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,6 +70,8 @@ train =
 cpu =
     torch==1.13.1
     torchvision==0.14.1
+# To install with gpu, you MUST specify the download URL with --extra-index-url
+# E.g.,pip install -e ".[gpu]" --extra-index-url https://download.pytorch.org/whl/cu117
 gpu =
     torch==1.13.1+cu117
     torchvision==0.14.1+cu117

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,9 +46,7 @@ install_requires =
     pillow>=10.2.0
     pydicom==2.3.0
     pylibjpeg[all]==2.0.0
-    torch==1.13.1
     torchio==0.18.74
-    torchvision==0.14.1
     tqdm==4.62.3
 
 [options.packages.find]
@@ -69,6 +67,9 @@ train =
     lifelines==0.26.4
     pytorch_lightning==1.6.0
     scikit-learn==1.0.2
+cpu =
+    torch==1.13.1
+    torchvision==0.14.1
 gpu =
     torch==1.13.1+cu117
     torchvision==0.14.1+cu117

--- a/tests/regression_test.py
+++ b/tests/regression_test.py
@@ -115,7 +115,7 @@ class TestPredict(unittest.TestCase):
     def test_demo_data(self):
         if not os.environ.get("SYBIL_TEST_RUN_REGRESSION", "false").lower() == "true":
             import pytest
-            pytest.skip(f"Skipping long-running test in {type(self)}.")
+            pytest.skip(f"Skipping long-running test in {type(self)}. Set SYBIL_TEST_RUN_REGRESSION=true if you wish to run this test.")
 
         if device_utils.get_default_device().type == "cpu":
             warnings.warn(
@@ -209,7 +209,7 @@ class TestPredictionRegression(unittest.TestCase):
     def test_nlst_predict(self, allow_resume=True, delete_downloaded_files=False):
         if not os.environ.get("SYBIL_TEST_RUN_REGRESSION", "false").lower() == "true":
             import pytest
-            pytest.skip(f"Skipping long-running test in {type(self)}.")
+            pytest.skip(f"Skipping long-running test in {type(self)}. Set SYBIL_TEST_RUN_REGRESSION=true if you wish to run this test.")
 
         test_series_list = test_series_uids.split("\n")
         test_series_list = [x.strip() for x in test_series_list if x.strip()]
@@ -332,7 +332,7 @@ class TestPredictionRegression(unittest.TestCase):
     def test_compare_predict_scores(self):
         if not os.environ.get("SYBIL_TEST_RUN_REGRESSION", "false").lower() == "true":
             import pytest
-            pytest.skip(f"Skipping long-running test '{type(self)}'.")
+            pytest.skip(f"Skipping long-running test '{type(self)}'. Set SYBIL_TEST_RUN_REGRESSION=true if you wish to run this test.")
 
         default_baseline_preds_path = os.path.join(PROJECT_DIR, "tests",
                                                    "nlst_predictions", "nlst_predictions_ark_v1.4.0.json")

--- a/tests/regression_test.py
+++ b/tests/regression_test.py
@@ -120,7 +120,8 @@ class TestPredict(unittest.TestCase):
         if device_utils.get_default_device().type == "cpu":
             warnings.warn(
                 "Sybil runs extremely slowly without a GPU. "
-                "Consider testing it in this cloud environment: https://lightning.ai/kiyaanpillai-org/notebook-experimentation-project/studios/data-exploration-devbox/code?source=copylink",
+                "Consider testing it in this cloud environment: https://lightning.ai/kiyaanpillai-org/notebook-experimentation-project/studios/data-exploration-devbox/code?source=copylink. "
+                "(You may have to create a Lightning AI account)",
                 UserWarning,
                 stacklevel=1,
             )

--- a/tests/regression_test.py
+++ b/tests/regression_test.py
@@ -120,7 +120,7 @@ class TestPredict(unittest.TestCase):
         if device_utils.get_default_device().type == "cpu":
             warnings.warn(
                 "Sybil runs extremely slowly without a GPU. "
-                "Consider testing it in this cloud environment: https://lightning.ai/kiyaanpillai-org/notebook-experimentation-project/studios/data-exploration-devbox/code?source=copylink. "
+                "Consider testing it in this cloud environment: https://lightning.ai/kiyaanpillai-org/notebook-experimentation-project/studios/sybil-playground/code?source=copylink. "
                 "(You may have to create a Lightning AI account)",
                 UserWarning,
                 stacklevel=1,

--- a/tests/regression_test.py
+++ b/tests/regression_test.py
@@ -117,6 +117,14 @@ class TestPredict(unittest.TestCase):
             import pytest
             pytest.skip(f"Skipping long-running test in {type(self)}.")
 
+        if device_utils.get_default_device().type == "cpu":
+            warnings.warn(
+                "Sybil runs extremely slowly without a GPU. "
+                "Consider testing it in this cloud environment: https://lightning.ai/kiyaanpillai-org/notebook-experimentation-project/studios/data-exploration-devbox/code?source=copylink",
+                UserWarning,
+                stacklevel=1,
+            )
+
         # Download demo data
         demo_data_url = "https://www.dropbox.com/scl/fi/covbvo6f547kak4em3cjd/sybil_example.zip?rlkey=7a13nhlc9uwga9x7pmtk1cf1c&st=dqi0cf9k&dl=1"
         expected_scores = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.15
-envlist = default
+envlist = cpu
 
 
 [testenv]
@@ -14,10 +14,16 @@ deps =
     setuptools
     pytest
     pytest-cov
+    requests
     # flake8
     # mypy
     # black
-install_command = pip install --pre --extra-index-url https://download.pytorch.org/whl/cu117/torch_stable.html {opts} {packages}
+extras =
+    cpu: cpu
+    gpu: gpu
+# GPU wheels need the CUDA index; CPU can use PyPI
+cpu: install_command = pip install --pre {opts} {packages}
+gpu: install_command = pip install --pre --extra-index-url https://download.pytorch.org/whl/cu117 {opts} {packages}
 commands =
     pytest {posargs}
     # black {toxinidir}/sybil --check

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps =
     # flake8
     # mypy
     # black
-install_command = pip install --pre --find-links https://download.pytorch.org/whl/cu117/torch_stable.html {opts} {packages}
+install_command = pip install --pre --extra-index-url https://download.pytorch.org/whl/cu117/torch_stable.html {opts} {packages}
 commands =
     pytest {posargs}
     # black {toxinidir}/sybil --check


### PR DESCRIPTION
As part of preparing Sybil for external testing, we made the following changes to improve the out-of-the-box experience for users evaluating the model:

* If a user runs `tests/regression_test.py` on a CPU, Sybil now displays a warning explaining that inference may be extremely slow without a GPU. The warning provides a link to our recommended cloud testing environment: [https://lightning.ai/kiyaanpillai-org/notebook-experimentation-project/studios/sybil-playground/code?source=copylink](https://lightning.ai/kiyaanpillai-org/notebook-experimentation-project/studios/sybil-playground/code?source=copylink). This provides a Colab-style notebook with Sybil preinstalled, allowing users to begin testing immediately.

* **Potentially breaking change:** Packaging for PyTorch has been reworked. Previously, `pip install sybil` attempted to install the CUDA build of PyTorch on x86_64 systems. In practice, users on a CPU don't need to wait for the required CUDA wheels (`torch==1.13.1+cu117` / `torchvision==0.14.1+cu117`) to install. Additionally, the requirement to manually specify `--extra-index-url https://download.pytorch.org/whl/cu117` was undocumented in setup.cfg.

  The default installation no longer installs torch. `pip install -e "."` succeeds out of the box on all supported platforms. GPU users can opt into CUDA support with: `pip install -e ".[gpu]" --extra-index-url https://download.pytorch.org/whl/cu117`, and CPU users who wish to install torch may run `pip install -e ".[cpu]".

  I updated tox.ini as well. When testing, you must now run `tox -e cpu` or `tox -e gpu`. Simply running `tox` defaults to `tox -e cpu`.

  This is a potentially breaking change for existing GPU users, who must now explicitly request the gpu extra. However, it fixes the installation time for CPU users and makes the default installation work out of the box, while preserving GPU support through a single additional install flag.

* Finally, the wiki may need to change to remain up-to-date. Because I can't make a PR to the wiki content, I've left a separate comment below outlining recommended changes.

All changes were tested on an Ubuntu Intel Core Ultra 7 258V × 8 (sybil[cpu]) as well as on Lightning.ai with a Intel(R) Xeon(R) Platinum 8259CL and a T4 GPU (sybil[gpu]). Tox and all tests in `tests/` pass on both devices.